### PR TITLE
Ccp 2057

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ typings/
 # dotenv environment variables file
 .env
 
+# ignore config
+extension/config.json
+frontend/config.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This extension will removed deposit amount from items prices for products that have a triggering product property. A hint will be added to the product indicating that a deposit will be added. The total deposit amount will be added as a cart sub total line.
 
+## Configuration
+triggerProductProperties
+```json
+{
+  "triggerProductProperties": [{"label": "battery_deposit", "value": "yes", "depositAmount": 7.99}]
+}
+```
+
 ## About Shopgate
 
 Shopgate is the leading mobile commerce platform.

--- a/extension-config.json
+++ b/extension-config.json
@@ -18,7 +18,6 @@
     {
       "path": "extension/addDepositAmount.js",
       "hooks": [
-        "shopgate.catalog.getProducts.v1:afterFetchProducts",
         "shopgate.catalog.getProductsByIds.v1:afterFetchProducts"
       ],
       "input": [

--- a/extension-config.json
+++ b/extension-config.json
@@ -4,5 +4,64 @@
   "components": [
   ],
   "configuration": {
-  }
+    "triggerProductProperties": {
+      "type": "admin",
+      "destination": "both",
+      "default": [],
+      "params": {
+        "label": "triggering product properties with deposit amount",
+        "type": "json"
+      }
+    }
+  },
+  "steps": [
+    {
+      "path": "extension/addDepositAmount.js",
+      "hooks": [
+        "shopgate.catalog.getProducts.v1:afterFetchProducts",
+        "shopgate.catalog.getProductsByIds.v1:afterFetchProducts"
+      ],
+      "input": [
+        {
+          "key": "products"
+        }
+      ],
+      "output": [
+        {
+          "key": "products"
+        }
+      ]
+    },
+    {
+      "path": "extension/deductDepositFromPrice.js",
+      "hooks": [
+        "shopgate.catalog.getProductsByIds.v1:after"
+      ],
+      "input": [
+        {
+          "key": "products"
+        }
+      ],
+      "output": [
+        {
+          "key": "products"
+        }
+      ]
+    },
+    {
+      "path": "extension/exposeDepositAmountInProduct.js",
+      "hooks": ["shopgate.catalog.getProduct.v1:afterFetchProducts"],
+      "input": [
+        {
+          "key": "products"
+        }
+      ],
+      "output": [
+        {
+          "key": "separatedDepositAmount",
+          "addPipelineOutput": true
+        }
+      ]
+    }
+  ]
 }

--- a/extension/addDepositAmount.js
+++ b/extension/addDepositAmount.js
@@ -1,0 +1,26 @@
+module.exports = async (context, { products = [] }) => {
+  const { triggerProductProperties = [] } = context.config
+  const updatedProducts = products.map((product) => {
+    const { properties = [] } = product
+    const depositAmount = properties.reduce((total, property) => {
+      const matchingTriggerProperty = triggerProductProperties.find(triggerProperty => (
+        triggerProperty.label === property.label && triggerProperty.value === property.value
+      ))
+
+      if (!matchingTriggerProperty) {
+        return total
+      }
+
+      let { depositAmount: propertyDepositAmount } = matchingTriggerProperty
+      propertyDepositAmount = propertyDepositAmount && !isNaN(propertyDepositAmount) ? parseFloat(propertyDepositAmount) : 0
+
+      return total + propertyDepositAmount
+    }, 0)
+    return {
+      ...product,
+      separatedDepositAmount: depositAmount
+    }
+  })
+
+  return { products: updatedProducts }
+}

--- a/extension/deductDepositFromPrice.js
+++ b/extension/deductDepositFromPrice.js
@@ -22,7 +22,6 @@ module.exports = async (context, { products = [] }) => {
 const adjustProductPrice = (price, separatedDepositAmount) => {
   const newPrice = { ...price }
   if (!separatedDepositAmount) {
-
     return newPrice
   }
 
@@ -34,7 +33,6 @@ const adjustProductPrice = (price, separatedDepositAmount) => {
   if (Array.isArray(newPrice.tiers) && newPrice.tiers.length) {
     newPrice.tiers = newPrice.tiers.map((tier) => {
       if (!tier.unitPrice) {
-
         return tier
       }
 

--- a/extension/deductDepositFromPrice.js
+++ b/extension/deductDepositFromPrice.js
@@ -26,7 +26,6 @@ const adjustProductPrice = (price, separatedDepositAmount) => {
   }
 
   PRICE_PROPS_TO_ADJUST.forEach((key) => {
-    console.log(`price adjustment key ${key} value ${newPrice[key]}`)
     newPrice[key] = deductAmount(newPrice[key], separatedDepositAmount)
   })
 

--- a/extension/deductDepositFromPrice.js
+++ b/extension/deductDepositFromPrice.js
@@ -1,0 +1,63 @@
+const PRICE_PROPS_TO_ADJUST = ['unitPrice', 'unitPriceStriked', 'unitPriceNet', 'unitPriceWithTax']
+
+module.exports = async (context, { products = [] }) => {
+  const updatedProducts = products.map((product) => {
+    const { price, separatedDepositAmount = 0 } = product
+    return {
+      ...product,
+      price: adjustProductPrice(price, separatedDepositAmount)
+    }
+  })
+
+  return { products: updatedProducts }
+}
+
+/**
+ * Adjust product price by deducting deposit amount
+ * @param {Object} price Price object
+ * @param {number} separatedDepositAmount Deposit amount to deduct
+ *
+ * @return {Object}
+ */
+const adjustProductPrice = (price, separatedDepositAmount) => {
+  const newPrice = { ...price }
+  if (!separatedDepositAmount) {
+
+    return newPrice
+  }
+
+  PRICE_PROPS_TO_ADJUST.forEach((key) => {
+    console.log(`price adjustment key ${key} value ${newPrice[key]}`)
+    newPrice[key] = deductAmount(newPrice[key], separatedDepositAmount)
+  })
+
+  if (Array.isArray(newPrice.tiers) && newPrice.tiers.length) {
+    newPrice.tiers = newPrice.tiers.map((tier) => {
+      if (!tier.unitPrice) {
+
+        return tier
+      }
+
+      return {
+        ...tier,
+        unitPrice: deductAmount(tier.unitPrice, separatedDepositAmount)
+      }
+    })
+  }
+
+  return newPrice
+}
+
+/**
+ *
+ * @param {number} originalAmount Original price
+ * @param {number} separatedDepositAmount Deposit amount to deduct
+ * @return {number}
+ */
+const deductAmount = (originalAmount, separatedDepositAmount) => {
+  if (originalAmount < separatedDepositAmount) {
+    return originalAmount
+  }
+
+  return originalAmount - separatedDepositAmount
+}

--- a/extension/exposeDepositAmountInProduct.js
+++ b/extension/exposeDepositAmountInProduct.js
@@ -1,0 +1,9 @@
+module.exports = async (context, { products = [] }) => {
+  if (!(products.length)) {
+    return
+  }
+
+  const { separatedDepositAmount = 0 } = products[0]
+
+  return { separatedDepositAmount }
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -10,12 +10,12 @@
     "bunyan": "^1.8.12",
     "@types/bunyan": "^1.8.4",
     "lint-staged": "^6.0.0",
-    "eslint": "^4.18.2",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.9.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint": "^5.13.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
The triggerProductProperties config is used to identify products that have a deposit included and it includes the amount of the deposit that is included. 

`"triggerProductProperties": [{"label": "battery_deposit", "value": "yes", "depositAmount": 7.99}]`

An additional property is added to the product object called separatedDepositAmount. This is used in a later hook step (where price becomes available) to deduct the deposit from the price, and it will be used in the frontend to add the deposit hint to products that have an additional deposit amount.